### PR TITLE
Correcting the name for Cisco's CyberOps Associate

### DIFF
--- a/Security-Certification-Roadmap7.html
+++ b/Security-Certification-Roadmap7.html
@@ -572,7 +572,7 @@
                 border-radius: 0.25vmax;
                 grid-column: span 5;
         }
-        
+
         .blueopsitem9, .blueopsitem9:hover {
                 background: var(--blue);
                 color: #ffffff;
@@ -949,7 +949,8 @@
         $1,999 exam
         SANS course recommended" tabindex="0" target="_blank" rel="noopener noreferrer">GSNA</a>
                         <div class="spacer5"></div>
-                        <div class="spacer"></div>
+                        <a class="blueopsitem1" href="https://www.iacis.com/certification/cawfe/" data-tooltip="IACIS Certified Advanced Windows Forensic Examiner
+        $750 written exam &amp; lab" tabindex="0" target="_blank" rel="noopener noreferrer">CAWFE</a>
                         <a class="blueopsitem2" href="https://www.giac.org/certification/gcfa" data-tooltip="GIAC Certified Forensic Analyst
         $1,999 exam
         SANS course recommended" tabindex="0" target="_blank" rel="noopener noreferrer">GCFA</a>
@@ -997,10 +998,17 @@
                         <a class="mgmtitem1" href="https://www.giac.org/certification/gisp" data-tooltip="GIAC Information Security Professional
         $1,999 exam
         SANS course recommended" tabindex="0" target="_blank" rel="noopener noreferrer">GISP</a>
-                        <div class="spacer10"></div>
+                        <div class="spacer5"></div>
                         <div class="spacer"></div>
-                        <a class="blueopsitem1" href="https://www.iacis.com/certification/cawfe/" data-tooltip="IACIS Certified Advanced Windows Forensic Examiner
-        $750 written exam &amp; lab" tabindex="0" target="_blank" rel="noopener noreferrer">CAWFE</a>
+                        <div class="spacer"></div>
+                        <a class="softwareitem1" href="https://www.giac.org/certification/secure-software-programmer-java-gssp-java" data-tooltip="GIAC Secure Software Programmer JAVA or .NET
+        $1,999 exam
+        SANS course recommended" tabindex="0" target="_blank">GSSP</a>
+                        <div class="spacer"></div>
+                        <div class="spacer"></div>
+                        <div class="spacer"></div>
+                        <a class="blueopsitem1" href="https://www.opentext.com/products-and-solutions/services/training-and-learning-services/encase-training/forensic-security-responder-certification" data-tooltip="OpenText Certified Forensic Security Responder
+        $250 written exam &amp; lab" tabindex="0" target="_blank" rel="noopener noreferrer">CFSR</a>
                         <a class="blueopsitem1" href="https://www.giac.org/certification/network-forensic-analyst-gnfa" data-tooltip="GIAC Network Forensic Analyst
         $1,999 exam
         SANS course recommended" tabindex="0" target="_blank" rel="noopener noreferrer">GNFA</a>
@@ -1040,14 +1048,8 @@
         $1,999 exam
         SANS course recommended" tabindex="0" target="_blank" rel="noopener noreferrer">GSLC</a>
                         <div class="spacer10"></div>
-                        <a class="softwareitem1" href="https://www.giac.org/certification/secure-software-programmer-java-gssp-java" data-tooltip="GIAC Secure Software Programmer JAVA or .NET
-        $1,999 exam
-        SANS course recommended" tabindex="0" target="_blank" rel="noopener noreferrer">GSSP</a>
-                        <div class="spacer"></div>
-                        <div class="spacer"></div>
-                        <div class="spacer"></div>
-                        <a class="blueopsitem1" href="https://www.opentext.com/products-and-solutions/services/training-and-learning-services/encase-training/forensic-security-responder-certification" data-tooltip="OpenText Certified Forensic Security Responder
-        $250 written exam &amp; lab" tabindex="0" target="_blank" rel="noopener noreferrer">CFSR</a>
+                        <a class="blueopsitem3" href="https://elearnsecurity.com/product/ecmap-certification/" data-tooltip="eLearnSecurity Certified Malware Analysis Professional
+        $400 exam" tabindex="0" target="_blank">eCMAP</a>
                         <a class="blueopsitem2" href="https://www.giac.org/certification/gcfe" data-tooltip="GIAC Cerified Forensics Examiner
         $1,999 exam
         SANS course recommended" tabindex="0" target="_blank" rel="noopener noreferrer">GCFE</a>
@@ -1161,7 +1163,9 @@
                         <a class="engineeritem1" href="https://www.giac.org/certification/cloud-security-automation-gcsa" data-tooltip="GIAC Cloud Security Automation
         $1999 exam
         SANS course recommended" tabindex="0" target="_blank" rel="noopener noreferrer">GCSA</a>
-                        <div class="spacer"></div>
+                        <a class="engineeritem1" href="https://www.giac.org/certification/certified-windows-security-administrator-gcwn" data-tooltip="GIAC Certified Windows Security Administrator
+        $1,999 exam
+        SANS course encouraged" tabindex="0" target="_blank" rel="noopener noreferrer">GCWN</a>
                         <a class="engineeritem1" href="https://www.giac.org/certification/response-industrial-defense-grid" data-tooltip="GIAC Response and Industrial Defense
         $1,999 exam
         SANS course encouraged" tabindex="0" target="_blank" rel="noopener noreferrer">GRID</a>
@@ -1221,9 +1225,8 @@
                         <a class="engineeritem1" href="https://www.vmware.com/education-services/certification/vcp-dcv.html" data-tooltip="VMware Certified Professional in Datacenter Virtualization
         $375 exam
         Branded course required" tabindex="0" target="_blank" rel="noopener noreferrer">VCP DCV</a>
-                        <a class="engineeritem1" href="https://www.giac.org/certification/certified-windows-security-administrator-gcwn" data-tooltip="GIAC Certified Windows Security Administrator
-        $1,999 exam
-        SANS course encouraged" tabindex="0" target="_blank" rel="noopener noreferrer">GCWN</a>
+                                <a class="engineeritem1" href="https://training.linuxfoundation.org/certification/linux-foundation-certified-sysadmin-lfcs/" data-tooltip="Linux Foundation Certified System Administrator
+        $300 exam" tabindex="0" target="_blank" rel="noopener noreferrer">LFCSA</a>
                         <a class="engineeritem1" href="https://www.isa.org/training-and-certifications/isa-certification/isa99iec-62443/isa99iec-62443-cybersecurity-certificate-programs/" data-tooltip="ISA Certified Design Specialist
         $2,700 course + exam
         Course required" tabindex="0" target="_blank" rel="noopener noreferrer">ISA CDS</a>
@@ -1470,8 +1473,8 @@
                         <a class="softwareitem1" href="https://gaqm.org/certifications/software_security_testing/casst" data-tooltip="GAQM Certified Advanced Software Security Tester
         $210 exam" tabindex="0" target="_blank" rel="noopener noreferrer">CASST</a>
                         <div class="spacer"></div>
-                        <div class="spacer"></div>
-                        <div class="spacer"></div>
+                        <a class="blueopsitem2" href="https://www.cisco.com/c/en/us/training-events/training-certifications/certifications/associate/cyberops-associate.html" data-tooltip="Cisco Certified CyberOps Associate Cyber Operations
+        ~$325 exam" tabindex="0" target="_blank">Cisco CyberOps Associate</a>
                         <div class="spacer"></div>
                         <a class="blueopsitem1" href="https://www.eccouncil.org/programs/computer-hacking-forensic-investigator-chfi/" data-tooltip="EC Council Computer Hacking Forensics Investigator
         $650 exam" tabindex="0" target="_blank" rel="noopener noreferrer">CHFI</a>
@@ -1495,8 +1498,7 @@
                         <div class="spacer"></div>
                         <a class="networkitem1" href="https://view.ceros.com/f5/certification-roadmap/p/9?heightOverride=740" data-tooltip="F5 Big-IP Certified Technical Specialist - Domain Name Services
         $135 exam" tabindex="0" target="_blank" rel="noopener noreferrer">F5 CTS DNS</a>
-                        <a class="networkitem1" href="https://www.cisco.com/c/en/us/training-events/training-certifications/certifications/associate/cyberops-associate.html" data-tooltip="Cisco Certified CyberOps Associate 
-                        ~$325 exam" tabindex="0" target="_blank" rel="noopener noreferrer">CCCOA</a>
+                        <div class="spacer"></div>
                         <div class="spacer"></div>
                         <div class="spacer"></div>
                         <div class="spacer"></div>

--- a/Security-Certification-Roadmap7.html
+++ b/Security-Certification-Roadmap7.html
@@ -1495,8 +1495,8 @@
                         <div class="spacer"></div>
                         <a class="networkitem1" href="https://view.ceros.com/f5/certification-roadmap/p/9?heightOverride=740" data-tooltip="F5 Big-IP Certified Technical Specialist - Domain Name Services
         $135 exam" tabindex="0" target="_blank" rel="noopener noreferrer">F5 CTS DNS</a>
-                        <a class="networkitem1" href="https://www.cisco.com/c/en/us/training-events/training-certifications/certifications/associate/cyberops-associate.html" data-tooltip="Cisco Certified Network Associate Cyber Operations
-        ~$325 exam" tabindex="0" target="_blank" rel="noopener noreferrer">CCCOA</a>
+                        <a class="networkitem1" href="https://www.cisco.com/c/en/us/training-events/training-certifications/certifications/associate/cyberops-associate.html" data-tooltip="Cisco Certified CyberOps Associate 
+                        ~$325 exam" tabindex="0" target="_blank" rel="noopener noreferrer">CCCOA</a>
                         <div class="spacer"></div>
                         <div class="spacer"></div>
                         <div class="spacer"></div>


### PR DESCRIPTION
The correct name for Cisco's SECOPS/CyberOps certification track is "Cisco Certified CyberOps Associate".