### PR TITLE
CCCOA should be under Security Operations

### DIFF
--- a/Security-Certification-Roadmap7.html
+++ b/Security-Certification-Roadmap7.html
@@ -1412,6 +1412,8 @@
         $200 two exams" tabindex="0" target="_blank" rel="noopener noreferrer">EnCE</a>
                         <a class="blueopsitem1" href="https://accessdata.com/training/computer-forensics-certification" data-tooltip="AccessData Certified Examiner
         $100 + software" tabindex="0" target="_blank" rel="noopener noreferrer">ACE</a>
+        <a class="blueopsitem1" href="https://www.cisco.com/c/en/us/training-events/training-certifications/certifications/associate/cyberops-associate.html" data-tooltip="Cisco Certified Network Associate Cyber Operations
+        ~$325 exam" tabindex="0" target="_blank" rel="noopener noreferrer">CCCOA</a>
                         <div class="spacer"></div>
                         <div class="spacer"></div>
                         <div class="spacer"></div>
@@ -1479,6 +1481,8 @@
         $400 lab" tabindex="0" target="_blank" rel="noopener noreferrer">eCIR</a>
                         <a class="blueopsitem1" href="https://www.eccouncil.org/programs/ec-council-certified-incident-handler-ecih/" data-tooltip="EC Council Certified Incident Handler
         $300 exam" tabindex="0" target="_blank" rel="noopener noreferrer">ECIH</a>
+        <a class="blueopsitem1" href="https://www.cisco.com/c/en/us/training-events/training-certifications/certifications/associate/cyberops-associate.html" data-tooltip="Cisco Certified Network Associate Cyber Operations
+        ~$325 exam" tabindex="0" target="_blank" rel="noopener noreferrer">CCCOA</a>
                         <a class="redopsitem1" href="https://mile2.com/certified-powershell-hacker" data-tooltip="Mile2 Certified Powershell Hacker
         $400 exam" tabindex="0" target="_blank" rel="noopener noreferrer">C)PSH</a>
                         <a class="redopsitem1" href="http://www.iacertification.org/cmwapt_certified_moigosible_and_web_app_penetration_tester.html" data-tooltip="IACRB Certified Mobile and Web App Penetration Tester
@@ -1495,8 +1499,6 @@
                         <div class="spacer"></div>
                         <a class="networkitem1" href="https://view.ceros.com/f5/certification-roadmap/p/9?heightOverride=740" data-tooltip="F5 Big-IP Certified Technical Specialist - Domain Name Services
         $135 exam" tabindex="0" target="_blank" rel="noopener noreferrer">F5 CTS DNS</a>
-                        <a class="networkitem1" href="https://www.cisco.com/c/en/us/training-events/training-certifications/certifications/associate/cyberops-associate.html" data-tooltip="Cisco Certified Network Associate Cyber Operations
-        ~$325 exam" tabindex="0" target="_blank" rel="noopener noreferrer">CCCOA</a>
                         <div class="spacer"></div>
                         <div class="spacer"></div>
                         <div class="spacer"></div>


### PR DESCRIPTION
Cisco CyberOps Associate should be under Security Operations > Incident handling vs. Network Security (that's where the old CCNA Security belonged). There is also a professional level CyberOps certification. I will address that in a separate pull request.