### PR TITLE
Add LFCSA

### DIFF
--- a/Security-Certification-Roadmap7.html
+++ b/Security-Certification-Roadmap7.html
@@ -1161,7 +1161,9 @@
                         <a class="engineeritem1" href="https://www.giac.org/certification/cloud-security-automation-gcsa" data-tooltip="GIAC Cloud Security Automation
         $1999 exam
         SANS course recommended" tabindex="0" target="_blank" rel="noopener noreferrer">GCSA</a>
-                        <div class="spacer"></div>
+                        <a class="engineeritem1" href="https://www.giac.org/certification/certified-windows-security-administrator-gcwn" data-tooltip="GIAC Certified Windows Security Administrator
+        $1,999 exam
+        SANS course encouraged" tabindex="0" target="_blank" rel="noopener noreferrer">GCWN</a>
                         <a class="engineeritem1" href="https://www.giac.org/certification/response-industrial-defense-grid" data-tooltip="GIAC Response and Industrial Defense
         $1,999 exam
         SANS course encouraged" tabindex="0" target="_blank" rel="noopener noreferrer">GRID</a>

--- a/Security-Certification-Roadmap7.html
+++ b/Security-Certification-Roadmap7.html
@@ -1161,7 +1161,6 @@
                         <a class="engineeritem1" href="https://www.giac.org/certification/cloud-security-automation-gcsa" data-tooltip="GIAC Cloud Security Automation
         $1999 exam
         SANS course recommended" tabindex="0" target="_blank" rel="noopener noreferrer">GCSA</a>
-
                         <div class="spacer"></div>
                         <a class="engineeritem1" href="https://www.giac.org/certification/response-industrial-defense-grid" data-tooltip="GIAC Response and Industrial Defense
         $1,999 exam
@@ -1224,10 +1223,6 @@
         Branded course required" tabindex="0" target="_blank" rel="noopener noreferrer">VCP DCV</a>
                                 <a class="engineeritem1" href="https://training.linuxfoundation.org/certification/linux-foundation-certified-sysadmin-lfcs/" data-tooltip="Linux Foundation Certified System Administrator
         $300 exam" tabindex="0" target="_blank" rel="noopener noreferrer">LFCSA</a>
-
-
-
-
                         <a class="engineeritem1" href="https://www.isa.org/training-and-certifications/isa-certification/isa99iec-62443/isa99iec-62443-cybersecurity-certificate-programs/" data-tooltip="ISA Certified Design Specialist
         $2,700 course + exam
         Course required" tabindex="0" target="_blank" rel="noopener noreferrer">ISA CDS</a>

--- a/Security-Certification-Roadmap7.html
+++ b/Security-Certification-Roadmap7.html
@@ -1161,6 +1161,7 @@
                         <a class="engineeritem1" href="https://www.giac.org/certification/cloud-security-automation-gcsa" data-tooltip="GIAC Cloud Security Automation
         $1999 exam
         SANS course recommended" tabindex="0" target="_blank" rel="noopener noreferrer">GCSA</a>
+
                         <div class="spacer"></div>
                         <a class="engineeritem1" href="https://www.giac.org/certification/response-industrial-defense-grid" data-tooltip="GIAC Response and Industrial Defense
         $1,999 exam
@@ -1221,9 +1222,12 @@
                         <a class="engineeritem1" href="https://www.vmware.com/education-services/certification/vcp-dcv.html" data-tooltip="VMware Certified Professional in Datacenter Virtualization
         $375 exam
         Branded course required" tabindex="0" target="_blank" rel="noopener noreferrer">VCP DCV</a>
-                        <a class="engineeritem1" href="https://www.giac.org/certification/certified-windows-security-administrator-gcwn" data-tooltip="GIAC Certified Windows Security Administrator
-        $1,999 exam
-        SANS course encouraged" tabindex="0" target="_blank" rel="noopener noreferrer">GCWN</a>
+                                <a class="engineeritem1" href="https://training.linuxfoundation.org/certification/linux-foundation-certified-sysadmin-lfcs/" data-tooltip="Linux Foundation Certified System Administrator
+        $300 exam" tabindex="0" target="_blank" rel="noopener noreferrer">LFCSA</a>
+
+
+
+
                         <a class="engineeritem1" href="https://www.isa.org/training-and-certifications/isa-certification/isa99iec-62443/isa99iec-62443-cybersecurity-certificate-programs/" data-tooltip="ISA Certified Design Specialist
         $2,700 course + exam
         Course required" tabindex="0" target="_blank" rel="noopener noreferrer">ISA CDS</a>


### PR DESCRIPTION
The Linux Foundation Certified Systems Administrator is a performance based cert similar to the RHCSA, but you can choose to take the exam on CentOS or Ubuntu.
It is said to be somewhat more demanding than the RHCSA, so I sorted it above that. (I don't hold the RHCSA, so can't compare.)