### PR TITLE
Fixed typo in S-CEHL Info Pop up

### DIFF
--- a/Security-Certification-Roadmap7.html
+++ b/Security-Certification-Roadmap7.html
@@ -1055,7 +1055,7 @@
     $339-749 Lab access
     Exam included" tabindex="0" target="_blank" >PACES</a>
                     <div class="spacer"></div>
-                    <a class="redopsitem1" href="https://www.seco-institute.org/certifications/ethical-hacking-certification-track/" data-tooltip="SECO Certified Etheical Hacker Leader
+                    <a class="redopsitem1" href="https://www.seco-institute.org/certifications/ethical-hacking-certification-track/" data-tooltip="SECO Certified Ethical Hacker Leader
     Application" tabindex="0" target="_blank" >S-CEHL</a>
                     <div class="spacer"></div>
                     <a class="redopsitem1" href="https://crest-approved.org/examination/registered-tester/index.html" data-tooltip="CREST Registered Penetration Tester


### PR DESCRIPTION
Changed "Etheical" to "Ethical" to align with correct spelling from SECO